### PR TITLE
Ci fix deprecation warnings

### DIFF
--- a/.github/workflows/codeql-analysis-go.yml
+++ b/.github/workflows/codeql-analysis-go.yml
@@ -34,24 +34,29 @@ jobs:
 
     - name: Get Change List
       id: check_file_changed
-      shell: pwsh
+      shell: bash
       run: |
-        # https://www.meziantou.net/executing-github-actions-jobs-or-steps-only-when-specific-files-change.htm#conditional-jobs
-
         # Diff HEAD with the previous commit then output to stdout.
-        echo "=== Which files changed? ===" | Out-String -Stream
-        ([string[]] $diff = git diff --name-only HEAD^ HEAD)
+        printf "=== Which files changed? ===\n"
+        GIT_DIFF="$(git diff --name-only HEAD^ HEAD)"
+        printf "%s\n" "${GIT_DIFF}"
+        printf "\n"
 
         # Check if the files are present in the changed file list (added, modified, deleted) then output to stdout.
-        echo "=== Which Golang files changed? ===" | Out-String -Stream
-        ([string[]] $SourceDiff = $diff | Where-Object { $_ -match '^.*[.]go$' -or $_ -match '^go[.]sum$' -or $_ -match '^go[.]mod$' })
+        HAS_DIFF=false
+        printf "=== Which Golang files changed? ===\n"
+        if printf "%s\n" "${GIT_DIFF}" | grep -E '^(.*[.]go|go[.](mod|sum)|.github/workflows/codeql-analysis-go.yml)$'; then
+          HAS_DIFF=true
+        fi
+        printf "\n"
 
         # Did Golang files change?
-        echo "=== Did Golang files change? ===" | Out-String -Stream
-        ([string[]] $HasDiff = $SourceDiff.Length -gt 0)
+        printf "=== Did Golang files change? ===\n"
+        printf "%s\n" "${HAS_DIFF}"
+        printf "\n"
 
         # Set the output named "docs_changed"
-        Write-Host "::set-output name=docs_changed::$HasDiff"
+        printf "%s=%s\n" "docs_changed" "${HAS_DIFF}" >> "${GITHUB_OUTPUT}"
 
   stage2-analyze:
     name: CodeQL Analyze

--- a/.github/workflows/fossa-go.yml
+++ b/.github/workflows/fossa-go.yml
@@ -29,24 +29,29 @@ jobs:
 
     - name: Get Change List
       id: check_file_changed
-      shell: pwsh
+      shell: bash
       run: |
-        # https://www.meziantou.net/executing-github-actions-jobs-or-steps-only-when-specific-files-change.htm#conditional-jobs
-
         # Diff HEAD with the previous commit then output to stdout.
-        echo "=== Which files changed? ===" | Out-String -Stream
-        ([string[]] $diff = git diff --name-only HEAD^ HEAD)
+        printf "=== Which files changed? ===\n"
+        GIT_DIFF="$(git diff --name-only HEAD^ HEAD)"
+        printf "%s\n" "${GIT_DIFF}"
+        printf "\n"
 
         # Check if the files are present in the changed file list (added, modified, deleted) then output to stdout.
-        echo "=== Did LICENSE, go.mod or go.sum files change? ===" | Out-String -Stream
-        ([string[]] $SourceDiff = $diff | Where-Object { $_ -match '^LICENSE$' -or $_ -match '^go.(sum|mod)$' })
+        HAS_DIFF=false
+        printf "=== Which Golang files changed? ===\n"
+        if printf "%s\n" "${GIT_DIFF}" | grep -E '^(LICENSE|go[.](mod|sum)|.github/workflows/fossa-go.yml)$'; then
+          HAS_DIFF=true
+        fi
+        printf "\n"
 
-        # Did the files in question files change?
-        echo "=== Did the files in question files change? ===" | Out-String -Stream
-        ([string[]] $HasDiff = $SourceDiff.Length -gt 0)
+        # Did Golang files change?
+        printf "=== Did Golang files change? ===\n"
+        printf "%s\n" "${HAS_DIFF}"
+        printf "\n"
 
         # Set the output named "docs_changed"
-        Write-Host "::set-output name=docs_changed::$HasDiff"
+        printf "%s=%s\n" "docs_changed" "${HAS_DIFF}" >> "${GITHUB_OUTPUT}"
 
   stage2-analyze:
     name: FOSSA Analyze

--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -26,24 +26,29 @@ jobs:
 
     - name: Get Change List
       id: check_file_changed
-      shell: pwsh
+      shell: bash
       run: |
-        # https://www.meziantou.net/executing-github-actions-jobs-or-steps-only-when-specific-files-change.htm#conditional-jobs
-
         # Diff HEAD with the previous commit then output to stdout.
-        echo "=== Which files changed? ===" | Out-String -Stream
-        ([string[]] $diff = git diff --name-only HEAD^ HEAD)
+        printf "=== Which files changed? ===\n"
+        GIT_DIFF="$(git diff --name-only HEAD^ HEAD)"
+        printf "%s\n" "${GIT_DIFF}"
+        printf "\n"
 
         # Check if the files are present in the changed file list (added, modified, deleted) then output to stdout.
-        echo "=== Which GitHub Workflow/Action files changed? ===" | Out-String -Stream
-        ([string[]] $SourceDiff = $diff | Where-Object { $_ -match '^.github/workflows/.*[.]yml$' })
+        HAS_DIFF=false
+        printf "=== Which Golang files changed? ===\n"
+        if printf "%s\n" "${GIT_DIFF}" | grep -E '^.github/workflows/.*[.]yml$'; then
+          HAS_DIFF=true
+        fi
+        printf "\n"
 
-        # Did GitHub Workflow/Action files change?
-        echo "=== Did GitHub Workflow/Action files change? ===" | Out-String -Stream
-        ([string[]] $HasDiff = $SourceDiff.Length -gt 0)
+        # Did Golang files change?
+        printf "=== Did Golang files change? ===\n"
+        printf "%s\n" "${HAS_DIFF}"
+        printf "\n"
 
         # Set the output named "docs_changed"
-        Write-Host "::set-output name=docs_changed::$HasDiff"
+        printf "%s=%s\n" "docs_changed" "${HAS_DIFF}" >> "${GITHUB_OUTPUT}"
 
   stage2:
     name: GitHub Action Checks


### PR DESCRIPTION
- ci(gha): fix set-output deprecation notice and convert from pwsh to bash
- ci(fossa): rename action yaml file, fix set-output deprecation notice and convert from pwsh to bash
- ci(codeql): fix set-output deprecation notice and convert from pwsh to bash