### PR TITLE
Ci fix deprecation warnings

### DIFF
--- a/.github/workflows/bash.yml
+++ b/.github/workflows/bash.yml
@@ -6,6 +6,10 @@ name: Bash Workflow
 
 on: [pull_request]
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   shellcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql-analysis-go.yml
+++ b/.github/workflows/codeql-analysis-go.yml
@@ -105,7 +105,7 @@ jobs:
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    # Adding this because the image as a dead version of Go.
+    # Adding this because the image has a dead version of Go.
     - name: Set up Go ${{ matrix.go-version }}
       id: setup-go
       uses: actions/setup-go@v3

--- a/.github/workflows/codeql-analysis-go.yml
+++ b/.github/workflows/codeql-analysis-go.yml
@@ -14,6 +14,10 @@ on:
   schedule:
     - cron: '15 08 * * 6'
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   stage1-setup:
     name: Change Check
@@ -34,7 +38,6 @@ jobs:
 
     - name: Get Change List
       id: check_file_changed
-      shell: bash
       run: |
         # Diff HEAD with the previous commit then output to stdout.
         printf "=== Which files changed? ===\n"

--- a/.github/workflows/fossa-go.yml
+++ b/.github/workflows/fossa-go.yml
@@ -81,6 +81,14 @@ jobs:
       run: |
         curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
 
+    - name: Show FOSSA Help Screen
+      run: |
+        fossa --help
+
+    - name: Show FOSSA Targets
+      run: |
+        fossa list-targets
+
     - name: Run FOSSA Check
       run: |
         fossa analyze

--- a/.github/workflows/fossa-go.yml
+++ b/.github/workflows/fossa-go.yml
@@ -9,6 +9,10 @@ env:
 on:
   pull_request:
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   stage1-setup:
     name: Change Check
@@ -29,7 +33,6 @@ jobs:
 
     - name: Get Change List
       id: check_file_changed
-      shell: bash
       run: |
         # Diff HEAD with the previous commit then output to stdout.
         printf "=== Which files changed? ===\n"

--- a/.github/workflows/fossa-go.yml
+++ b/.github/workflows/fossa-go.yml
@@ -4,7 +4,7 @@
 name: "FOSSA Check"
 
 env:
-  FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+  FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY_FULL }}
 
 on:
   pull_request:
@@ -89,6 +89,10 @@ jobs:
       run: |
         fossa list-targets
 
-    - name: Run FOSSA Check
+    - name: Run FOSSA Analyze
       run: |
         fossa analyze
+
+    - name: Run FOSSA Test
+      run: |
+        fossa test

--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -101,7 +101,7 @@ jobs:
       run: |
         actionlint --version
 
-    - name: Analysing the code with golint
+    - name: Analysing the code with actionlint
       id: actionlint
       run: |
         echo "::add-matcher::.github/actionlint-matcher.json"

--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -6,6 +6,10 @@ on:
 env:
   REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   stage1:
     name: Change Check
@@ -26,7 +30,6 @@ jobs:
 
     - name: Get Change List
       id: check_file_changed
-      shell: bash
       run: |
         # Diff HEAD with the previous commit then output to stdout.
         printf "=== Which files changed? ===\n"
@@ -78,13 +81,11 @@ jobs:
 
     - name: Show Go version
       id: go-version-check
-      shell: bash
       run: |
         go version
 
     - name: Install Tools
       id: install-tools
-      shell: bash
       run: |
         go install github.com/reviewdog/reviewdog/cmd/reviewdog@latest
         go install github.com/rhysd/actionlint/cmd/actionlint@latest
@@ -92,19 +93,16 @@ jobs:
 
     - name: Reviewdog Version Checks
       id: version-check-reviewdog
-      shell: bash
       run: |
         reviewdog --version
 
     - name: Actionlint Version Checks
       id: version-check-actionlint
-      shell: bash
       run: |
         actionlint --version
 
     - name: Analysing the code with golint
       id: actionlint
-      shell: bash
       run: |
         echo "::add-matcher::.github/actionlint-matcher.json"
         for f in ./.github/workflows/*yml; do

--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -2,6 +2,10 @@ name: Git Workflow
 
 on: [pull_request]
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   block-fixup:
     runs-on: ubuntu-latest

--- a/.github/workflows/github-pages-hugo.yml
+++ b/.github/workflows/github-pages-hugo.yml
@@ -27,7 +27,6 @@ concurrency:
   group: "pages"
   cancel-in-progress: true
 
-# Default to bash
 defaults:
   run:
     shell: bash

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,6 +13,10 @@ env:
   OCTOCOV_VERSION: "0.40.1"
   REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   stage1:
     name: Change Check
@@ -33,7 +37,6 @@ jobs:
 
     - name: Get Change List
       id: check_file_changed
-      shell: bash
       run: |
         # Diff HEAD with the previous commit then output to stdout.
         printf "=== Which files changed? ===\n"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -160,7 +160,9 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: |
         go install github.com/client9/misspell/cmd/misspell@latest
-        misspell -error . | reviewdog -efm="%f:%l:%c: %m" -name="misspell" -reporter=github-pr-check
+        # misspell -error . | reviewdog -efm="%f:%l:%c: %m" -name="misspell" -reporter=github-pr-check
+        # not sure why this started failing when it doesn't find any issues
+        misspell . | reviewdog -efm="%f:%l:%c: %m" -name="misspell" -reporter=github-pr-check
 
     - name: Testing with ineffassign
       id: go-test-ineffassign

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -66,11 +66,6 @@ jobs:
       matrix:
         go-version: ["1.19"]
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        exclude:
-          - os: "macos-latest"
-            go-version: "1.19"
-          - os: "windows-latest"
-            go-version: "1.19"
 
     runs-on: "${{ matrix.os }}"
 
@@ -136,76 +131,89 @@ jobs:
 
     - name: Install Go Tools
       id: install-go-tools
+      if: matrix.os == 'ubuntu-latest'
       run: |
         go install github.com/reviewdog/reviewdog/cmd/reviewdog@latest
 
     - name: Analysing the code with golint
       id: golint
+      if: matrix.os == 'ubuntu-latest'
       run: |
         go install golang.org/x/lint/golint@latest
         golint -set_exit_status ./... | reviewdog -efm="%f:%l:%c: %m" -name="golint" -reporter=github-pr-check
 
     - name: Testing with revive
       id: go-test-revive
+      if: matrix.os == 'ubuntu-latest'
       run: |
         go install github.com/mgechev/revive@latest
         revive ./... | reviewdog -efm="%f:%l:%c: %m" -name="revive" -reporter=github-pr-check
 
     - name: Analysing the code with go vet
       id: go-vet
+      if: matrix.os == 'ubuntu-latest'
       run: |
         go vet ./... | reviewdog -efm="%f:%l:%c: %m" -name="go vet" -reporter=github-pr-check
 
     - name: Testing with misspell
       id: go-test-misspell
+      if: matrix.os == 'ubuntu-latest'
       run: |
         go install github.com/client9/misspell/cmd/misspell@latest
         misspell -error . | reviewdog -efm="%f:%l:%c: %m" -name="misspell" -reporter=github-pr-check
 
     - name: Testing with ineffassign
       id: go-test-ineffassign
+      if: matrix.os == 'ubuntu-latest'
       run: |
         go install github.com/gordonklaus/ineffassign@latest
         ineffassign ./... | reviewdog -efm="%f:%l:%c: %m" -name="ineffassign" -reporter=github-pr-check
 
     - name: Testing with gocyclo
       id: go-test-gocyclo
+      if: matrix.os == 'ubuntu-latest'
       run: |
         go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
         gocyclo -over "${GOCYCLO_OVER_THRESHOLD}" .
 
     - name: Testing with go-consistent
       id: go-test-go-consistent
+      if: matrix.os == 'ubuntu-latest'
       run: |
         go install github.com/quasilyte/go-consistent@latest
         go-consistent -v ./... | reviewdog -efm="%f:%l:%c: %m" -name="go-consistent" -reporter=github-pr-check
 
     - name: Testing with gocritic
       id: go-test-gocritic
+      if: matrix.os == 'ubuntu-latest'
       run: |
         go install github.com/go-critic/go-critic/cmd/gocritic@latest
         gocritic check -enableAll ./... |& reviewdog -efm="%f:%l:%c: %m" -name="gocritic" -reporter=github-pr-check
 
     - name: Testing with staticcheck
       id: go-test-staticcheck
+      if: matrix.os == 'ubuntu-latest'
       run: |
         go install honnef.co/go/tools/cmd/staticcheck@latest
         staticcheck ./... | reviewdog -efm="%f:%l:%c: %m" -name="staticcheck" -reporter=github-pr-check
 
     - name: Testing with golangci-lint
       id: go-test-golangci-lint
+      if: matrix.os == 'ubuntu-latest'
       run: |
         go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
         golangci-lint run --out-format=line-number ./... | reviewdog -f=golangci-lint -name="golangci-lint" -filter-mode=added -reporter=github-pr-check
 
     - name: Testing with gosec
       id: go-test-security
+      if: matrix.os == 'ubuntu-latest'
       run: |
         go install github.com/securego/gosec/v2/cmd/gosec@latest
         gosec ./... | reviewdog -efm="%f:%l:%c: %m" -name="gosec" -reporter=github-pr-check
 
     - name: Code Climate Code Coverage Setup
       id: go-code-climate-code-coverage-setup
+      if: matrix.os == 'ubuntu-latest'
       run: |
         curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
         chmod -v a+x ./cc-test-reporter
@@ -220,6 +228,7 @@ jobs:
 
     - name: Test Coverage Report (txt)
       id: go-test-coverage-txt
+      if: matrix.os == 'ubuntu-latest'
       run: |
         go tool cover -func=./reports/.coverage.out | tee reports/coverage.txt
 
@@ -230,6 +239,7 @@ jobs:
 
     - name: Upload coverage.html
       id: upload-coverage-html
+      if: matrix.os == 'ubuntu-latest'
       uses: actions/upload-artifact@v3
       with:
         name: go-coverage-html
@@ -243,6 +253,7 @@ jobs:
 
     - name: Upload coverage-annotations.txt
       id: upload-coverage-annotations-txt
+      if: matrix.os == 'ubuntu-latest'
       uses: actions/upload-artifact@v3
       with:
         name: go-coverage-annotations-txt
@@ -255,6 +266,7 @@ jobs:
 
     - name: Upload coverage-summary.txt
       id: upload-coverage-summary-txt
+      if: matrix.os == 'ubuntu-latest'
       uses: actions/upload-artifact@v3
       with:
         name: go-coverage-summary-txt
@@ -262,6 +274,7 @@ jobs:
 
     - name: Code Climate Code Coverage Report
       id: go-code-climate-code-coverage-report
+      if: matrix.os == 'ubuntu-latest'
       run: |
         cp -v ./reports/.coverage.out ./c.out
         ./cc-test-reporter after-build format-coverage -t gocov --prefix "${GH_REPO_URL}" ./reports/.coverage.out
@@ -285,6 +298,7 @@ jobs:
 
     - name: Action Summary
       id: gh-action-summary
+      if: matrix.os == 'ubuntu-latest'
       run: |
         {
           printf "### Code Coverage Summary\n\n"

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -11,6 +11,10 @@ on:
       - develop
   pull_request:
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   linkChecker:
     runs-on: ubuntu-latest

--- a/.github/workflows/woke.yml
+++ b/.github/workflows/woke.yml
@@ -7,6 +7,10 @@ name: Woke Workflow
 on:
   - pull_request
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   woke:
     name: woke


### PR DESCRIPTION
- ci(fossa): add an action summary
- ci(fossa): set the default run shell to bash
- ci(codeql): add an action summary
- ci(codeql): fix typo in comment
- ci(codeql): set the default run shell to bash
- ci(go): enable tests on windows and macos
- ci(go): set the default run shell to bash
- ci(woke): set the default run shell to bash
- ci(links): set the default run shell to bash
- ci(hugo): comment clean up
- ci(gha): fix typo in comment
- ci(gha): set the default run shell to bash
- ci(git): set the default run shell to bash
- ci(bash): set the default run shell to bash